### PR TITLE
The usage of deprecated functions may result in unreliable checks for contract existence, potentially leading to security vulnerabilities.

### DIFF
--- a/src/assertionStakingPool/StakingPoolCreatorUtils.sol
+++ b/src/assertionStakingPool/StakingPoolCreatorUtils.sol
@@ -11,8 +11,9 @@ import "@openzeppelin/contracts/utils/Address.sol";
 library StakingPoolCreatorUtils {
     error PoolDoesntExist();
     
-    function getPool(bytes memory creationCode, bytes memory args) internal view returns (address) {
-        bytes32 bytecodeHash = keccak256(abi.encodePacked(creationCode, args));
+    function getPool(bytes memory creationCode, bytes memory args, address implementsStakingPoolCreatorUtils) internal view returns (address) {
+        require(address(this) == implementsStakingPoolCreatorUtils, "mismatch");
+		bytes32 bytecodeHash = keccak256(abi.encodePacked(creationCode, args));
         address pool = Create2.computeAddress(0, bytecodeHash, address(this));
 		if (Address.functionStaticCall(pool, new bytes(0)).length == 0) {revert PoolDoesntExist();}
         return pool;

--- a/src/assertionStakingPool/StakingPoolCreatorUtils.sol
+++ b/src/assertionStakingPool/StakingPoolCreatorUtils.sol
@@ -11,8 +11,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
 library StakingPoolCreatorUtils {
     error PoolDoesntExist();
     
-    function getPool(bytes memory creationCode, bytes memory args, address implementsStakingPoolCreatorUtils) internal view returns (address) {
-        require(address(this) == implementsStakingPoolCreatorUtils, "mismatch");
+    function getPool(bytes memory creationCode, bytes memory args) internal view returns (address) {
 		bytes32 bytecodeHash = keccak256(abi.encodePacked(creationCode, args));
         address pool = Create2.computeAddress(0, bytecodeHash, address(this));
 		if (Address.functionStaticCall(pool, new bytes(0)).length == 0) {revert PoolDoesntExist();}

--- a/src/assertionStakingPool/StakingPoolCreatorUtils.sol
+++ b/src/assertionStakingPool/StakingPoolCreatorUtils.sol
@@ -3,20 +3,18 @@
 // SPDX-License-Identifier: BUSL-1.1
 //
 
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.25;
 
 import "@openzeppelin/contracts/utils/Create2.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 
 library StakingPoolCreatorUtils {
     error PoolDoesntExist();
+    
     function getPool(bytes memory creationCode, bytes memory args) internal view returns (address) {
         bytes32 bytecodeHash = keccak256(abi.encodePacked(creationCode, args));
         address pool = Create2.computeAddress(0, bytecodeHash, address(this));
-        if (Address.isContract(pool)) {
-            return pool;
-        } else {
-            revert PoolDoesntExist();
-        }
+		if (Address.functionStaticCall(pool, new bytes(0)).length == 0) {revert PoolDoesntExist();}
+        return pool;
     }
 }


### PR DESCRIPTION
Replace the usage of `Address.isContract` with more reliable and explicit functions such as `Address.functionStaticCall` for contract existence checks.